### PR TITLE
Update Makefile

### DIFF
--- a/demos/kyber1024/Makefile
+++ b/demos/kyber1024/Makefile
@@ -2,7 +2,7 @@
 
 LAZER_DIR = ../..
 
-LIBS = $(LAZER_DIR)/liblazer.a -lmpfr -lgmp -lm ../../third_party/hexl-development/build/hexl/lib64/libhexl.a -lstdc++ #XXX
+LIBS = $(LAZER_DIR)/liblazer.a -lmpfr -lgmp -lm ../../third_party/hexl-development/build/hexl/lib/libhexl.a -lstdc++ #XXX
 CFLAGS = -Wall -Wextra -Wshadow -Wundef -O3 -g
 
 all: kyber1024-demo


### PR DESCRIPTION
**Fix Makefile: Correct HEXL Library Path**

This pull request updates the Makefile to correct the path to the HEXL library. Previously, the Makefile referenced ../../third_party/hexl-development/build/hexl/lib64/libhexl.a, but the lib64 directory does not exist in the specified path.

**Changes Made**

> Updated the Makefile to use the correct path to libhexl.a, ensuring compatibility with the build structure.

**Impact**

    This fix ensures successful compilation of kyber1024-demo without manual intervention in the Makefile.

**Testing**

    Verified that the make command runs successfully after updating the path.