### PR TITLE
Update Makefile : Fix Library Path for HEXL in Makefile

### DIFF
--- a/demos/blindsig/Makefile
+++ b/demos/blindsig/Makefile
@@ -2,7 +2,7 @@
 
 LAZER_DIR = ../..
 
-LIBS = $(LAZER_DIR)/liblazer.a -lmpfr -lgmp -lm ../../third_party/hexl-development/build/hexl/lib64/libhexl.a -lstdc++ #XXX
+LIBS = $(LAZER_DIR)/liblazer.a -lmpfr -lgmp -lm ../../third_party/hexl-development/build/hexl/lib/libhexl.a -lstdc++ #XXX
 CFLAGS = -Wall -Wextra -Wshadow -Wundef -O3 -g
 
 all: blindsig-demo


### PR DESCRIPTION
This PR updates the Makefile to correct the path of the HEXL library. The previous version referenced lib64/libhexl.a, which has been modified to lib/libhexl.a to ensure compatibility with the latest build structure.

Reason for Change:

    The correct path for libhexl.a is lib/ instead of lib64/.
    Ensures compatibility with the current build setup.

Impact:

    Fixes build issues related to incorrect library paths.
    Ensures that the linking process completes successfully with the correct HEXL library.