### PR TITLE
Gaussian sampler improvements

### DIFF
--- a/src/grandom.c
+++ b/src/grandom.c
@@ -34,8 +34,7 @@ static const z128 CDF155[]
         { 0ULL, 0ULL } };
 
 /*
- * Compute exp(x) for x such that |x| <= 0.5*ln 2
- * FIXME: Recompute Remez coefficients for interval [-ln 2,0]
+ * Compute exp(x) for x in [-ln 2, 0]  
  *
  * The algorithm used below is derived from the public domain
  * library fdlibm (http://www.netlib.org/fdlibm/e_exp.c).
@@ -44,16 +43,17 @@ static const z128 CDF155[]
 static inline double
 exp_small (double x)
 {
-#define C1 (1.66666666666666019037e-01)
-#define C2 (-2.77777777770155933842e-03)
-#define C3 (6.61375632143793436117e-05)
-#define C4 (-1.65339022054652515390e-06)
-#define C5 (4.13813679705723846039e-08)
+#define C1 ( 1.66666666666666657415e-01)
+#define C2 (-2.77777777777722060387e-03)
+#define C3 ( 6.61375660702744565646e-05)
+#define C4 (-1.65343769616898187644e-06)
+#define C5 ( 4.17431906195525278958e-08)
+#define C6 (-1.02842107821646284274e-09)
 
   double t;
 
   t = x * x;
-  t = x - t * (C1 + t * (C2 + t * (C3 + t * (C4 + t * C5)))); // R1
+  t = x - t * (C1 + t * (C2 + t * (C3 + t * (C4 + t * (C5 + t * C6))))); // R1
   t = 1.0 - ((x * t) / (t - 2.0) - x);
   return t;
 
@@ -62,6 +62,7 @@ exp_small (double x)
 #undef C3
 #undef C4
 #undef C5
+#undef C6
 }
 
 static inline unsigned int

--- a/src/grandom.c
+++ b/src/grandom.c
@@ -30,8 +30,7 @@ static const z128 CDF155[]
         { 0ULL, 1055215183460ULL },
         { 0ULL, 724109373ULL },
         { 0ULL, 327744ULL },
-        { 0ULL, 98ULL },
-        { 0ULL, 0ULL } };
+        { 0ULL, 98ULL } };
 
 /*
  * Compute exp(x) for x in [-ln 2, 0]  

--- a/src/grandom.c
+++ b/src/grandom.c
@@ -66,17 +66,24 @@ exp_small (double x)
 }
 
 static inline unsigned int
-cdfsampler (rng_state_t state, const z128 CDF[])
+cdfsampler (rng_state_t state, const z128 CDF[], unsigned int len)
 {
-  uint64_t buf[2];
-  const uint64_t *hi = buf, *lo = buf + 1;
-  unsigned int z;
+  uint64_t buf[2], hi, lo, d;
+  unsigned int z, i;
+  int b0, b1, b2;
 
   rng_urandom (state, (unsigned char *)buf, 16);
+  hi = buf[0];
+  lo = buf[1];
 
   z = 0;
-  while (*hi <= CDF[z].hi && (*hi < CDF[z].hi || *lo < CDF[z].lo))
-    ++z;
+  for (i = 0; i < len; i++)
+    {
+      b0 = __builtin_sub_overflow (lo, CDF[i].lo, &d); // b0 = (lo < CDF[i].lo)
+      b1 = __builtin_sub_overflow (hi, CDF[i].hi, &d); // b1 = (hi < CDF[i].hi) 
+      b2 = __builtin_sub_overflow (d, (uint64_t)b0, &d); // d = 0 if (hi = CDF[i].hi). then, if b0 = 1, b2 = 1
+      z += (unsigned int)(b1 | b2); 
+    }
 
   return z;
 }
@@ -123,7 +130,7 @@ gaussian155 (rng_state_t state, double c)
       b = bits & 1;
       bits >>= 1;
       pos += 1;
-      k = cdfsampler (state, CDF155);
+      k = cdfsampler (state, CDF155, sizeof (CDF155) / sizeof (CDF155[0]));
       k = (-b & (2 * k)) - k + b; // bimodal Gaussian
       x = ((k - c) * (k - c) - (k - b) * (k - b)) * dss;
     }

--- a/src/grandom.c
+++ b/src/grandom.c
@@ -50,11 +50,20 @@ exp_small (double x)
 #define C5 ( 4.17431906195525278958e-08)
 #define C6 (-1.02842107821646284274e-09)
 
-  double t;
+  double t, d, y;
 
   t = x * x;
   t = x - t * (C1 + t * (C2 + t * (C3 + t * (C4 + t * (C5 + t * C6))))); // R1
-  t = 1.0 - ((x * t) / (t - 2.0) - x);
+
+  /* 1/(t - 2) via Newton (y <- y*(2 - d*y)) */
+  d = t - 2.0;
+  y = -0.4193;
+  y *= 2.0 - d * y;
+  y *= 2.0 - d * y;
+  y *= 2.0 - d * y;
+  y *= 2.0 - d * y;
+  y *= 2.0 - d * y;
+  t = 1.0 - (x * t * y - x); // == 1.0 - ((x * t) / (t - 2.0) - x)
   return t;
 
 #undef C1


### PR DESCRIPTION
1. Recalibrate Ramez coeffs

```sage
HI = RealField(200)
DBL = RealField(53)     
ln2 = log(HI(2))
L = ln2   # target: x in [-ln2, 0]

# The reconstruction 1 - (x*c/(c-2) - x) equals exp(x) exactly iff
# c = x*coth(x/2) - 2.  The code stores c = x - x^2*P(x^2), so P must match:
def g(x):
    x = HI(x)
    if x == 0:
        return HI(1)/6
    return (x/tanh(x/2) - 2)/x^2

def fit(d):                  # degree-d poly in z=x^2, interpolated at Chebyshev nodes
    nodes = [-L/2 + L/2*cos(HI(pi)*(2*k+1)/(2*(d+1))) for k in range(d+1)]
    A = matrix(HI, d+1, d+1, lambda i, j: nodes[i]^(2*j))
    b = vector(HI, [g(x) for x in nodes])
    return A.solve_right(b)

def exp_small(x, C, F): 
    x = F(x); z = x*x
    P = F(0)
    for c in reversed(list(C)):
        P = P*z + F(c)
    cc = x - z*P
    return 1 - ((x*cc)/(cc - 2) - x)

def max_rel_err(C, F, N=40000):
    m = HI(0)
    for k in range(N+1):
        x = -L*k/N
        m = max(m, abs(HI(exp_small(x, C, F)) - exp(HI(x))) / exp(HI(x)))
    return float(log(m)/ln2)

for d in [4, 5, 6]:
    C = fit(d)
    print("  degree %d (%d coeffs):  approx err 2^%.1f   double-precision err 2^%.1f"
          % (d, d+1, max_rel_err(C, HI), max_rel_err([DBL(c) for c in C], DBL)))

d = 5
for j, c in enumerate(fit(d)):
    print("#define C%d (%s)" % (j+1, DBL(c).hex()))
```

Re-calibrated to match the precision of `double`


2. Constant time `exp_small`

I start from a guess `y = -0.4193`, which is in the middle of `x \in [−ln2, 0]`. The worst-case initial error is then `0.16`. After 5  steps, we square the error to `2^-84`, below the `double` precision.  

3. Constant-time sweep over the CDF table using `__builtin_sub_overflow` -- standard trick for ct comparison. 